### PR TITLE
fix: satisfy clippy::unnecessary_sort_by from rust 1.96 stable

### DIFF
--- a/src/cli/analyze.rs
+++ b/src/cli/analyze.rs
@@ -155,7 +155,7 @@ pub(crate) async fn run_analyze(args: AnalyzeArgs) -> Result<(), Box<dyn std::er
     let total = tracks.len();
 
     // LPT scheduling: longest tracks first so short tracks fill gaps at the tail
-    to_analyze.sort_by(|a, b| b.0.length.cmp(&a.0.length));
+    to_analyze.sort_by_key(|b| std::cmp::Reverse(b.0.length));
 
     let pending = to_analyze.len();
 

--- a/src/cli/hydrate.rs
+++ b/src/cli/hydrate.rs
@@ -286,7 +286,7 @@ pub(crate) async fn run_hydrate(args: HydrateArgs) -> Result<(), Box<dyn std::er
     }
 
     // LPT scheduling: longest tracks first so short tracks fill gaps at the tail
-    analysis_pending.sort_by(|a, b| b.0.length.cmp(&a.0.length));
+    analysis_pending.sort_by_key(|b| std::cmp::Reverse(b.0.length));
 
     drop(store_conn);
 

--- a/src/musicbrainz.rs
+++ b/src/musicbrainz.rs
@@ -129,7 +129,7 @@ pub async fn lookup(
     let best_release_id = releases.and_then(|rels| {
         let mut scored: Vec<(&serde_json::Value, i32)> =
             rels.iter().map(|r| (r, score_release(r))).collect();
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by_key(|b| std::cmp::Reverse(b.1));
         scored
             .first()
             .and_then(|(r, _)| r.get("id").and_then(|v| v.as_str()))

--- a/src/tools/classify_handler.rs
+++ b/src/tools/classify_handler.rs
@@ -298,7 +298,7 @@ pub(super) fn build_genre_distribution(results: &[ClassificationResult]) -> serd
             (genre, conf_map, total)
         })
         .collect();
-    genres.sort_by(|a, b| b.2.cmp(&a.2));
+    genres.sort_by_key(|b| std::cmp::Reverse(b.2));
 
     genres
         .into_iter()
@@ -311,7 +311,7 @@ pub(super) fn build_genre_distribution(results: &[ClassificationResult]) -> serd
                 }
             }
             let mut top: Vec<_> = artist_counts.into_iter().collect();
-            top.sort_by(|a, b| b.1.cmp(&a.1));
+            top.sort_by_key(|b| std::cmp::Reverse(b.1));
             let top_artists: Vec<String> = top
                 .iter()
                 .take(5)
@@ -379,7 +379,7 @@ fn build_dispatch_groups(
     let total_artists = artist_map.len();
 
     let mut artists: Vec<_> = artist_map.into_iter().collect();
-    artists.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    artists.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
 
     let artists: Vec<serde_json::Value> = artists
         .into_iter()

--- a/src/tools/label_handlers.rs
+++ b/src/tools/label_handlers.rs
@@ -404,7 +404,7 @@ pub(super) async fn handle_backfill_labels(
                 *by_artist.entry(&t.artist).or_insert(0) += 1;
             }
             let mut artist_counts: Vec<_> = by_artist.into_iter().collect();
-            artist_counts.sort_by(|a, b| b.1.cmp(&a.1));
+            artist_counts.sort_by_key(|b| std::cmp::Reverse(b.1));
             let top_artists: Vec<_> = artist_counts
                 .iter()
                 .take(20)

--- a/src/tools/scoring.rs
+++ b/src/tools/scoring.rs
@@ -2426,7 +2426,7 @@ pub(super) fn find_bridge_tracks(pools: &[DiscoveredPool]) -> Vec<(String, Vec<u
         .into_iter()
         .filter(|(_, p)| p.len() >= 2)
         .collect();
-    bridges.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    bridges.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
     bridges
 }
 

--- a/src/tools/staging_handlers.rs
+++ b/src/tools/staging_handlers.rs
@@ -253,10 +253,10 @@ fn build_preview_summary(diffs: &[crate::types::TrackDiff]) -> serde_json::Value
     let total_field_changes: usize = by_field.values().sum();
 
     let mut by_field_sorted: Vec<_> = by_field.into_iter().collect();
-    by_field_sorted.sort_by(|a, b| b.1.cmp(&a.1));
+    by_field_sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     let mut by_genre_sorted: Vec<_> = by_genre.into_iter().collect();
-    by_genre_sorted.sort_by(|a, b| b.1.cmp(&a.1));
+    by_genre_sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     let by_field_arr: Vec<_> = by_field_sorted
         .into_iter()


### PR DESCRIPTION
## Summary

`cargo clippy --all-targets -- -D warnings` (the CI clippy gate) currently fails on `main` because rust 1.96 stable promoted `clippy::unnecessary_sort_by` to a stable warning. Ten call sites trigger it:

| File | Line |
|---|---|
| `src/cli/analyze.rs` | 158 |
| `src/cli/hydrate.rs` | 289 |
| `src/musicbrainz.rs` | 132 |
| `src/tools/classify_handler.rs` | 301, 314, 382 |
| `src/tools/label_handlers.rs` | 407 |
| `src/tools/scoring.rs` | 2429 |
| `src/tools/staging_handlers.rs` | 256, 259 |

Each `sort_by(\|a, b\| b.X.cmp(&a.X))` is rewritten as `sort_by_key(\|b\| std::cmp::Reverse(b.X))` — the exact form clippy suggests, semantically identical, and slightly cheaper.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` → clean
- [x] `cargo test -p reklawdbox` → 737 passed; 0 failed; 31 ignored
- [x] Manual diff review — every change is the clippy-suggested rewrite verbatim

## Notes

I noticed this while preparing a separate fixture-generation PR for stratum-dsp tests. Decided to send this as its own atomic change first so it can land cleanly. Happy to revise the style if you'd prefer a different idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)