### PR TITLE
fix(broker): restore Discogs through free Cloudflare Gateway

### DIFF
--- a/broker/README.md
+++ b/broker/README.md
@@ -56,6 +56,41 @@ the Worker `scheduled()` handler to prune expired rows from:
   - `ALLOW_UNAUTHENTICATED_BROKER=true` (dev override; client-token checks disabled), or
   - `BROKER_CLIENT_TOKEN` is unset while unauthenticated mode is disabled (fail-closed; protected routes return `401`).
 
+## Discogs throttling
+
+OAuth request-token, access-token, and search requests share the broker's
+request pacing. On an explicit Discogs HTTP 429, the broker records only the
+operation and numeric quota headers, then retries OAuth once after `Retry-After`. Search throttling returns
+immediately with retry instructions so the MCP client's 30-second request
+deadline does not hide the error.
+Missing or invalid retry instructions use 60 seconds; HTTP-date values are
+supported. If the requested wait exceeds 60 seconds, the broker returns it
+without retrying early. Network failures and other error statuses are not
+retried during token exchange.
+
+If throttling persists, the response is HTTP 429 with
+`error: "discogs_rate_limited"`, `retry_after_seconds`, and a `Retry-After`
+header. Wait for that interval before retrying the same authorization page.
+If the device session has expired, start a fresh lookup to obtain a new link.
+A throttled callback preserves its request-token state for a later attempt.
+
+A healthy `/v1/health` response does not test Discogs connectivity. Use
+`wrangler tail reklawdbox-discogs-broker` to inspect `discogs rate limit`
+events. Low broker traffic does not rule out a source-IP limit on shared
+Cloudflare egress; compare the quota headers and a controlled local request
+before changing credentials or introducing a separately hosted relay.
+
+If Wrangler reaches the OAuth callback but reports a connection timeout while
+fetching its Cloudflare token, first verify network connectivity. A per-process
+connection-attempt adjustment can help on slow IPv4/unavailable IPv6 paths:
+
+```sh
+NODE_OPTIONS=--network-family-autoselection-attempt-timeout=2000 wrangler login
+```
+
+Keep the login process running and approve the new browser page within its
+time limit. An old callback URL cannot complete an expired login attempt.
+
 ## Local dev
 
 ```bash

--- a/broker/README.md
+++ b/broker/README.md
@@ -55,12 +55,14 @@ the Worker `scheduled()` handler to prune expired rows from:
 - `status: "warning"` when either:
   - `ALLOW_UNAUTHENTICATED_BROKER=true` (dev override; client-token checks disabled), or
   - `BROKER_CLIENT_TOKEN` is unset while unauthenticated mode is disabled (fail-closed; protected routes return `401`).
+- `discogs_egress: "gateway"` when a `DISCOGS_EGRESS` network binding is configured, otherwise `"direct"`. This reports configuration, not a live upstream check.
 
 ## Discogs throttling
 
 OAuth request-token, access-token, and search requests share the broker's
-request pacing. On an explicit Discogs HTTP 429, the broker records only the
-operation and numeric quota headers, then retries OAuth once after `Retry-After`. Search throttling returns
+request pacing and a D1 cooldown deadline. On an explicit Discogs HTTP 429,
+the broker logs only the operation and numeric quota headers, records the
+cooldown, then retries OAuth once after `Retry-After`. Search throttling returns
 immediately with retry instructions so the MCP client's 30-second request
 deadline does not hide the error.
 Missing or invalid retry instructions use 60 seconds; HTTP-date values are
@@ -73,12 +75,49 @@ If throttling persists, the response is HTTP 429 with
 header. Wait for that interval before retrying the same authorization page.
 If the device session has expired, start a fresh lookup to obtain a new link.
 A throttled callback preserves its request-token state for a later attempt.
+While a cooldown is active, fresh upstream work returns the remaining wait
+without contacting Discogs. Valid cached search results remain available.
+Concurrent 429 responses preserve the longest cooldown.
+
+Requests can wait up to four seconds for a pacing slot. If the queue cannot
+fit that budget, the broker returns HTTP 503 with `error: "broker_busy"`,
+`retry_after_seconds`, and `Retry-After`, without growing the backlog.
+The CLI honors numeric retry instructions for both 429 and 503. It makes at
+most four attempts, with automatic waits of at most 120 seconds each; longer
+server instructions are returned unchanged for the user to retry later.
+MCP searches return these errors without an automatic retry. Errors never
+become cached search misses.
 
 A healthy `/v1/health` response does not test Discogs connectivity. Use
 `wrangler tail reklawdbox-discogs-broker` to inspect `discogs rate limit`
 events. Low broker traffic does not rule out a source-IP limit on shared
 Cloudflare egress; compare the quota headers and a controlled local request
 before changing credentials or introducing a separately hosted relay.
+
+## Cloudflare egress
+
+The maintained deployment binds `DISCOGS_EGRESS` to the account's
+`cf1:network` VPC network. All Discogs OAuth and search calls use its Gateway
+route. A failure on that route returns an error; it does not silently switch
+to ordinary Worker egress.
+
+[Workers VPC is free during its open beta](https://developers.cloudflare.com/workers-vpc/reference/pricing/),
+subject to normal Worker quotas. Gateway uses shared egress; this is not an
+exclusive or static IP and does not guarantee immunity to future throttling.
+[Dedicated Gateway egress IPs require a paid Enterprise add-on](https://developers.cloudflare.com/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/).
+
+`wrangler.toml` pins the maintained personal Cloudflare account. Self-hosters
+must change `account_id` and the D1 database configuration to their own account.
+Deploying a VPC binding requires the `connectivity:admin` OAuth scope in
+addition to the Worker deployment scopes. Baseline tests select the `test`
+environment, disable remote bindings, and supply an isolated D1 database.
+They require neither Cloudflare credentials nor real Discogs traffic.
+
+To diagnose an egress regression, compare a small number of controlled real
+Discogs requests through Gateway and ordinary Worker egress. Verify OAuth and
+an uncached search as well as health before declaring recovery. Removing the
+network binding restores the direct route, which may restore the original
+shared-IP failure. No D1 migration is required for the shared cooldown.
 
 If Wrangler reaches the OAuth callback but reports a connection timeout while
 fetching its Cloudflare token, first verify network connectivity. A per-process

--- a/broker/src/discogs-rate-limit.ts
+++ b/broker/src/discogs-rate-limit.ts
@@ -1,0 +1,68 @@
+const MAX_AUTOMATIC_WAIT_SECONDS = 60
+const DEFAULT_RETRY_AFTER_SECONDS = 60
+
+type DiscogsStage = 'request_token' | 'access_token' | 'search'
+
+export class DiscogsRateLimitError extends Error {
+  constructor(readonly retryAfterSeconds: number) {
+    super(
+      `Discogs is rate limiting requests from this broker. Wait ${retryAfterSeconds} seconds before retrying.`,
+    )
+    this.name = 'DiscogsRateLimitError'
+  }
+}
+
+// Retry only an explicit rejection, never a timeout or an ambiguous token exchange.
+export async function withDiscogsRateLimitRecovery(
+  stage: DiscogsStage,
+  send: () => Promise<Response>,
+): Promise<Response> {
+  for (let attempt = 0;; attempt++) {
+    const response = await send()
+    if (response.status !== 429) return response
+
+    const retryAfterSeconds =
+      parseRetryAfterSeconds(response.headers.get('Retry-After'))
+        ?? DEFAULT_RETRY_AFTER_SECONDS
+    console.warn('discogs rate limit', {
+      stage,
+      retry_after_seconds: retryAfterSeconds,
+      limit: numericHeader(response.headers.get('X-Discogs-Ratelimit')),
+      remaining: numericHeader(
+        response.headers.get('X-Discogs-Ratelimit-Remaining'),
+      ),
+      used: numericHeader(response.headers.get('X-Discogs-Ratelimit-Used')),
+    })
+    await response.body?.cancel()
+
+    // MCP clients have a 30-second total request deadline. Return the retry
+    // instruction immediately for searches instead of hiding it behind a wait.
+    if (
+      stage === 'search' || attempt > 0
+      || retryAfterSeconds > MAX_AUTOMATIC_WAIT_SECONDS
+    ) {
+      throw new DiscogsRateLimitError(retryAfterSeconds)
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, retryAfterSeconds * 1000)
+    )
+  }
+}
+
+function numericHeader(value: string | null): number | null {
+  if (value === null || !/^\d+$/.test(value.trim())) return null
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
+
+function parseRetryAfterSeconds(value: string | null): number | null {
+  if (!value?.trim()) return null
+  const seconds = numericHeader(value)
+  if (seconds !== null) return seconds
+  // Numeric-looking malformed values must not be interpreted as dates.
+  if (!/^[A-Za-z]{3},/.test(value.trim())) return null
+  const deadline = Date.parse(value)
+  return Number.isFinite(deadline)
+    ? Math.max(0, Math.ceil((deadline - Date.now()) / 1000))
+    : null
+}

--- a/broker/src/discogs-rate-limit.ts
+++ b/broker/src/discogs-rate-limit.ts
@@ -12,16 +12,26 @@ export class DiscogsRateLimitError extends Error {
   }
 }
 
+export class DiscogsQueueBusyError extends Error {
+  constructor(readonly retryAfterSeconds: number) {
+    super(
+      `The broker request queue is busy. Retry after ${retryAfterSeconds} seconds.`,
+    )
+    this.name = 'DiscogsQueueBusyError'
+  }
+}
+
 // Retry only an explicit rejection, never a timeout or an ambiguous token exchange.
 export async function withDiscogsRateLimitRecovery(
   stage: DiscogsStage,
   send: () => Promise<Response>,
+  recordCooldown: (seconds: number) => Promise<number | void> = async () => {},
 ): Promise<Response> {
   for (let attempt = 0;; attempt++) {
     const response = await send()
     if (response.status !== 429) return response
 
-    const retryAfterSeconds =
+    let retryAfterSeconds =
       parseRetryAfterSeconds(response.headers.get('Retry-After'))
         ?? DEFAULT_RETRY_AFTER_SECONDS
     console.warn('discogs rate limit', {
@@ -33,7 +43,14 @@ export async function withDiscogsRateLimitRecovery(
       ),
       used: numericHeader(response.headers.get('X-Discogs-Ratelimit-Used')),
     })
-    await response.body?.cancel()
+    try {
+      const sharedDelay = await recordCooldown(retryAfterSeconds)
+      if (sharedDelay !== undefined) {
+        retryAfterSeconds = Math.max(retryAfterSeconds, sharedDelay)
+      }
+    } finally {
+      await response.body?.cancel()
+    }
 
     // MCP clients have a 30-second total request deadline. Return the retry
     // instruction immediately for searches instead of hiding it behind a wait.

--- a/broker/src/index.ts
+++ b/broker/src/index.ts
@@ -1,5 +1,6 @@
 import { BERKELEY_MONO_FONT_DATA_URI, CALLBACK_LOGO_DATA_URI } from './branding'
 import {
+  DiscogsQueueBusyError,
   DiscogsRateLimitError,
   withDiscogsRateLimitRecovery,
 } from './discogs-rate-limit'
@@ -16,6 +17,7 @@ interface Env {
   SESSION_TOKEN_TTL_SECONDS?: string
   SEARCH_CACHE_TTL_SECONDS?: string
   DISCOGS_MIN_INTERVAL_MS?: string
+  DISCOGS_EGRESS?: Fetcher
 }
 
 type SessionStatus = 'pending' | 'authorized' | 'finalized' | 'expired'
@@ -101,6 +103,9 @@ const DISCOGS_UPSTREAM_INVALID_RESPONSE_MESSAGE =
 const BROKER_USER_AGENT = 'reklawdbox-broker/0.1'
 const MAX_RATE_LIMIT_CAS_RETRIES = 20
 const DISCOGS_FETCH_TIMEOUT_MS = 20_000
+// Leave room for the upstream fetch and broker I/O within the client's 30s timeout.
+const MAX_DISCOGS_QUEUE_WAIT_MS = 4_000
+const DISCOGS_COOLDOWN_BUCKET = 'discogs-api-cooldown'
 const MAX_JSON_BODY_BYTES = 8 * 1024
 const MAX_SESSION_FIELD_LENGTH = 256
 const MAX_SEARCH_FIELD_LENGTH = 256
@@ -174,6 +179,16 @@ export default {
           message: err.message,
           retry_after_seconds: err.retryAfterSeconds,
         }, 429)
+        response.headers.set('Retry-After', `${err.retryAfterSeconds}`)
+        return response
+      }
+
+      if (err instanceof DiscogsQueueBusyError) {
+        const response = json({
+          error: 'broker_busy',
+          message: err.message,
+          retry_after_seconds: err.retryAfterSeconds,
+        }, 503)
         response.headers.set('Retry-After', `${err.retryAfterSeconds}`)
         return response
       }
@@ -869,7 +884,20 @@ async function handleHealth(env: Env): Promise<Response> {
   return json({
     status: brokerClientAuth.warning ? 'warning' : 'ok',
     broker_client_auth: brokerClientAuth,
+    discogs_egress: env.DISCOGS_EGRESS ? 'gateway' : 'direct',
   })
+}
+
+function fetchDiscogs(
+  env: Env,
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  // A configured route fails closed; an upstream failure must not silently
+  // switch back to the shared Worker fetch route.
+  return env.DISCOGS_EGRESS
+    ? env.DISCOGS_EGRESS.fetch(url, init)
+    : fetch(url, init)
 }
 
 async function lookupDiscogsViaApi(
@@ -905,7 +933,8 @@ async function lookupDiscogsViaApi(
         `${env.DISCOGS_CONSUMER_SECRET}&${params.oauthTokenSecret}`,
     }
     try {
-      return await fetch(
+      return await fetchDiscogs(
+        env,
         `${DISCOGS_BASE_URL}/database/search?${query.toString()}`,
         {
           method: 'GET',
@@ -926,7 +955,11 @@ async function lookupDiscogsViaApi(
     }
   }
 
-  const response = await withDiscogsRateLimitRecovery('search', doRequest)
+  const response = await withDiscogsRateLimitRecovery(
+    'search',
+    doRequest,
+    (seconds) => recordDiscogsCooldown(env, seconds),
+  )
 
   if (!response.ok) {
     console.error('discogs search returned non-success status', response.status)
@@ -1138,7 +1171,8 @@ async function requestDiscogsRequestToken(
     async () => {
       await enforceDiscogsRateLimit(env)
       oauthParams.oauth_nonce = randomToken(16)
-      return fetch(`${DISCOGS_BASE_URL}/oauth/request_token`, {
+      oauthParams.oauth_timestamp = `${nowSeconds()}`
+      return fetchDiscogs(env, `${DISCOGS_BASE_URL}/oauth/request_token`, {
         method: 'POST',
         headers: {
           Authorization: oauthHeader(oauthParams),
@@ -1154,6 +1188,7 @@ async function requestDiscogsRequestToken(
         )
       })
     },
+    (seconds) => recordDiscogsCooldown(env, seconds),
   )
 
   if (!response.ok) {
@@ -1213,7 +1248,8 @@ async function requestDiscogsAccessToken(
     async () => {
       await enforceDiscogsRateLimit(env)
       oauthParams.oauth_nonce = randomToken(16)
-      return fetch(`${DISCOGS_BASE_URL}/oauth/access_token`, {
+      oauthParams.oauth_timestamp = `${nowSeconds()}`
+      return fetchDiscogs(env, `${DISCOGS_BASE_URL}/oauth/access_token`, {
         method: 'POST',
         headers: {
           Authorization: oauthHeader(oauthParams),
@@ -1229,6 +1265,7 @@ async function requestDiscogsAccessToken(
         )
       })
     },
+    (seconds) => recordDiscogsCooldown(env, seconds),
   )
 
   if (!response.ok) {
@@ -1360,11 +1397,19 @@ async function enforceDiscogsRateLimit(env: Env): Promise<void> {
     env.DISCOGS_MIN_INTERVAL_MS,
     DEFAULT_DISCOGS_MIN_INTERVAL_MS,
   )
+  const queueDeadlineMs = Date.now() + MAX_DISCOGS_QUEUE_WAIT_MS
 
   for (let attempt = 0; attempt < MAX_RATE_LIMIT_CAS_RETRIES; attempt++) {
+    await assertDiscogsCooldownExpired(env)
+    if (Date.now() >= queueDeadlineMs) {
+      throw new DiscogsQueueBusyError(1)
+    }
     if (attempt > 0) {
       // Jittered backoff to reduce D1 contention under concurrent load
-      await delay(Math.floor(Math.random() * 50 * (attempt + 1)))
+      await delay(Math.min(
+        Math.floor(Math.random() * 50 * (attempt + 1)),
+        Math.max(0, queueDeadlineMs - Date.now()),
+      ))
     }
 
     const nowMs = Date.now()
@@ -1376,6 +1421,10 @@ async function enforceDiscogsRateLimit(env: Env): Promise<void> {
       .bind(bucket)
       .first<{ last_request_at_ms: number }>()
 
+    if (Date.now() >= queueDeadlineMs) {
+      throw new DiscogsQueueBusyError(1)
+    }
+
     if (!row) {
       const insertResult = await env.DB.prepare(
         `INSERT INTO rate_limit_state (bucket, last_request_at_ms)
@@ -1386,6 +1435,8 @@ async function enforceDiscogsRateLimit(env: Env): Promise<void> {
         .run()
 
       if ((insertResult.meta.changes ?? 0) === 1) {
+        await assertDiscogsCooldownExpired(env)
+        if (Date.now() >= queueDeadlineMs) throw new DiscogsQueueBusyError(1)
         return
       }
       continue
@@ -1393,6 +1444,12 @@ async function enforceDiscogsRateLimit(env: Env): Promise<void> {
 
     const lastRequestAtMs = Number(row.last_request_at_ms)
     const reservedAtMs = Math.max(lastRequestAtMs + minIntervalMs, nowMs)
+    if (reservedAtMs >= queueDeadlineMs) {
+      // Reject without advancing a backlog that cannot fit the request budget.
+      throw new DiscogsQueueBusyError(
+        Math.max(1, Math.ceil((reservedAtMs - Date.now()) / 1000)),
+      )
+    }
     const updateResult = await env.DB.prepare(
       `UPDATE rate_limit_state
        SET last_request_at_ms = ?1
@@ -1403,18 +1460,51 @@ async function enforceDiscogsRateLimit(env: Env): Promise<void> {
       .run()
 
     if ((updateResult.meta.changes ?? 0) === 1) {
-      const waitMs = reservedAtMs - nowMs
+      const waitMs = reservedAtMs - Date.now()
       if (waitMs > 0) {
         await delay(waitMs)
       }
+      await assertDiscogsCooldownExpired(env)
+      if (Date.now() >= queueDeadlineMs) throw new DiscogsQueueBusyError(1)
       return
     }
   }
 
-  throw new BrokerHttpError(
-    'service_unavailable',
-    'rate limiter contention exceeded retries',
-    503,
+  throw new DiscogsQueueBusyError(1)
+}
+
+async function assertDiscogsCooldownExpired(env: Env): Promise<void> {
+  const row = await env.DB.prepare(
+    'SELECT last_request_at_ms FROM rate_limit_state WHERE bucket = ?1',
+  ).bind(DISCOGS_COOLDOWN_BUCKET).first<{ last_request_at_ms: number }>()
+  const remainingMs = Number(row?.last_request_at_ms ?? 0) - Date.now()
+  if (remainingMs > 0) {
+    throw new DiscogsRateLimitError(Math.ceil(remainingMs / 1000))
+  }
+}
+
+async function recordDiscogsCooldown(
+  env: Env,
+  seconds: number,
+): Promise<number> {
+  const deadlineMs = Math.min(
+    Number.MAX_SAFE_INTEGER,
+    Date.now() + seconds * 1000,
+  )
+  const row = await env.DB.prepare(
+    `INSERT INTO rate_limit_state (bucket, last_request_at_ms)
+     VALUES (?1, ?2)
+     ON CONFLICT(bucket) DO UPDATE SET
+       last_request_at_ms = MAX(rate_limit_state.last_request_at_ms, excluded.last_request_at_ms)
+     RETURNING last_request_at_ms`,
+  ).bind(DISCOGS_COOLDOWN_BUCKET, deadlineMs).first<
+    { last_request_at_ms: number }
+  >()
+  return Math.max(
+    seconds,
+    Math.ceil(
+      (Number(row?.last_request_at_ms ?? deadlineMs) - Date.now()) / 1000,
+    ),
   )
 }
 

--- a/broker/src/index.ts
+++ b/broker/src/index.ts
@@ -1,4 +1,8 @@
 import { BERKELEY_MONO_FONT_DATA_URI, CALLBACK_LOGO_DATA_URI } from './branding'
+import {
+  DiscogsRateLimitError,
+  withDiscogsRateLimitRecovery,
+} from './discogs-rate-limit'
 
 interface Env {
   DB: D1Database
@@ -95,7 +99,6 @@ const DISCOGS_UPSTREAM_FAILURE_MESSAGE = 'discogs upstream request failed'
 const DISCOGS_UPSTREAM_INVALID_RESPONSE_MESSAGE =
   'discogs upstream response was invalid'
 const BROKER_USER_AGENT = 'reklawdbox-broker/0.1'
-const MAX_RETRY_AFTER_SECONDS = 60
 const MAX_RATE_LIMIT_CAS_RETRIES = 20
 const DISCOGS_FETCH_TIMEOUT_MS = 20_000
 const MAX_JSON_BODY_BYTES = 8 * 1024
@@ -164,6 +167,16 @@ export default {
       )
     } catch (err) {
       console.error('broker request failed', err)
+
+      if (err instanceof DiscogsRateLimitError) {
+        const response = json({
+          error: 'discogs_rate_limited',
+          message: err.message,
+          retry_after_seconds: err.retryAfterSeconds,
+        }, 429)
+        response.headers.set('Retry-After', `${err.retryAfterSeconds}`)
+        return response
+      }
 
       if (err instanceof BrokerHttpError) {
         return json(
@@ -913,16 +926,7 @@ async function lookupDiscogsViaApi(
     }
   }
 
-  let response = await doRequest()
-  if (response.status === 429) {
-    const retryAfterSeconds = parseRetryAfterSeconds(
-      response.headers.get('Retry-After'),
-    )
-    await delay(
-      Math.min(retryAfterSeconds ?? 30, MAX_RETRY_AFTER_SECONDS) * 1000,
-    )
-    response = await doRequest()
-  }
+  const response = await withDiscogsRateLimitRecovery('search', doRequest)
 
   if (!response.ok) {
     console.error('discogs search returned non-success status', response.status)
@@ -1129,21 +1133,28 @@ async function requestDiscogsRequestToken(
     oauth_signature: `${env.DISCOGS_CONSUMER_SECRET}&`,
   }
 
-  const response = await fetch(`${DISCOGS_BASE_URL}/oauth/request_token`, {
-    method: 'POST',
-    headers: {
-      Authorization: oauthHeader(oauthParams),
-      'User-Agent': BROKER_USER_AGENT,
+  const response = await withDiscogsRateLimitRecovery(
+    'request_token',
+    async () => {
+      await enforceDiscogsRateLimit(env)
+      oauthParams.oauth_nonce = randomToken(16)
+      return fetch(`${DISCOGS_BASE_URL}/oauth/request_token`, {
+        method: 'POST',
+        headers: {
+          Authorization: oauthHeader(oauthParams),
+          'User-Agent': BROKER_USER_AGENT,
+        },
+        signal: AbortSignal.timeout(DISCOGS_FETCH_TIMEOUT_MS),
+      }).catch((err) => {
+        console.error('discogs request_token call failed', err)
+        throw new BrokerHttpError(
+          'discogs_unavailable',
+          DISCOGS_UPSTREAM_FAILURE_MESSAGE,
+          502,
+        )
+      })
     },
-    signal: AbortSignal.timeout(DISCOGS_FETCH_TIMEOUT_MS),
-  }).catch((err) => {
-    console.error('discogs request_token call failed', err)
-    throw new BrokerHttpError(
-      'discogs_unavailable',
-      DISCOGS_UPSTREAM_FAILURE_MESSAGE,
-      502,
-    )
-  })
+  )
 
   if (!response.ok) {
     console.error(
@@ -1197,21 +1208,28 @@ async function requestDiscogsAccessToken(
     oauth_signature: `${env.DISCOGS_CONSUMER_SECRET}&${oauthTokenSecret}`,
   }
 
-  const response = await fetch(`${DISCOGS_BASE_URL}/oauth/access_token`, {
-    method: 'POST',
-    headers: {
-      Authorization: oauthHeader(oauthParams),
-      'User-Agent': BROKER_USER_AGENT,
+  const response = await withDiscogsRateLimitRecovery(
+    'access_token',
+    async () => {
+      await enforceDiscogsRateLimit(env)
+      oauthParams.oauth_nonce = randomToken(16)
+      return fetch(`${DISCOGS_BASE_URL}/oauth/access_token`, {
+        method: 'POST',
+        headers: {
+          Authorization: oauthHeader(oauthParams),
+          'User-Agent': BROKER_USER_AGENT,
+        },
+        signal: AbortSignal.timeout(DISCOGS_FETCH_TIMEOUT_MS),
+      }).catch((err) => {
+        console.error('discogs access_token call failed', err)
+        throw new BrokerHttpError(
+          'discogs_unavailable',
+          DISCOGS_UPSTREAM_FAILURE_MESSAGE,
+          502,
+        )
+      })
     },
-    signal: AbortSignal.timeout(DISCOGS_FETCH_TIMEOUT_MS),
-  }).catch((err) => {
-    console.error('discogs access_token call failed', err)
-    throw new BrokerHttpError(
-      'discogs_unavailable',
-      DISCOGS_UPSTREAM_FAILURE_MESSAGE,
-      502,
-    )
-  })
+  )
 
   if (!response.ok) {
     console.error(
@@ -1941,17 +1959,6 @@ function envIntClamped(
   max: number,
 ): number {
   return Math.min(envInt(input, fallback), max)
-}
-
-function parseRetryAfterSeconds(header: string | null): number | null {
-  if (!header) {
-    return null
-  }
-  const parsed = Number.parseInt(header, 10)
-  if (Number.isFinite(parsed) && parsed > 0) {
-    return parsed
-  }
-  return null
 }
 
 function safeJsonParse<T>(input: string): T | null {

--- a/broker/tests/broker.test.ts
+++ b/broker/tests/broker.test.ts
@@ -493,6 +493,16 @@ describe('broker test runner baseline', () => {
         "SELECT COUNT(*) as count FROM oauth_request_tokens WHERE oauth_token = 'req-token'",
       ).first<{ count: number }>()
       expect(Number(retained?.count)).toBe(1)
+      const stillThrottled = await request(
+        callback,
+        { method: 'GET' },
+        overrides,
+      )
+      expect(stillThrottled.status).toBe(429)
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+      await env.DB.prepare(
+        "UPDATE rate_limit_state SET last_request_at_ms = ?1 WHERE bucket = 'discogs-api-cooldown'",
+      ).bind(Date.now() - 1).run()
       const completed = await request(callback, { method: 'GET' }, overrides)
       expect(completed.status).toBe(200)
       const authorized = await env.DB.prepare(

--- a/broker/tests/broker.test.ts
+++ b/broker/tests/broker.test.ts
@@ -415,6 +415,100 @@ describe('broker test runner baseline', () => {
     }
   })
 
+  it('returns actionable OAuth throttling without storing a failed request token', async () => {
+    const start = await request('/v1/device/session/start', {
+      method: 'POST',
+      headers: { [TOKEN_HEADER]: env.BROKER_CLIENT_TOKEN },
+    })
+    const started = await start.json<{ auth_url: string }>()
+    const url = new URL(started.auth_url)
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('private upstream detail', {
+        status: 429,
+        headers: { 'Retry-After': '120' },
+      }),
+    )
+    try {
+      const response = await request(url.pathname + url.search, {
+        method: 'GET',
+      })
+      expect(response.status).toBe(429)
+      expect(response.headers.get('Retry-After')).toBe('120')
+      expect(response.headers.get('Cache-Control')).toBe('no-store')
+      const body = await response.json<
+        { error: string; message: string; retry_after_seconds: number }
+      >()
+      expect(body.error).toBe('discogs_rate_limited')
+      expect(body.retry_after_seconds).toBe(120)
+      expect(body.message).not.toContain('private upstream detail')
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      const rows = await env.DB.prepare(
+        'SELECT COUNT(*) as count FROM oauth_request_tokens',
+      ).first<{ count: number }>()
+      expect(Number(rows?.count)).toBe(0)
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it('preserves a throttled callback so the same approval can complete later', async () => {
+    const start = await request('/v1/device/session/start', {
+      method: 'POST',
+      headers: { [TOKEN_HEADER]: env.BROKER_CLIENT_TOKEN },
+    })
+    const started = await start.json<{ auth_url: string }>()
+    const url = new URL(started.auth_url)
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response('oauth_token=req-token&oauth_token_secret=req-secret'),
+      )
+      .mockResolvedValueOnce(
+        new Response('private upstream detail', {
+          status: 429,
+          headers: { 'Retry-After': '120' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          'oauth_token=access-token&oauth_token_secret=access-secret',
+        ),
+      )
+    const overrides = { DISCOGS_MIN_INTERVAL_MS: '1' }
+    try {
+      expect(
+        (await request(url.pathname + url.search, { method: 'GET' }, overrides))
+          .status,
+      ).toBe(302)
+      const callback = '/v1/discogs/oauth/callback' + url.search
+        + '&oauth_token=req-token&oauth_verifier=verifier'
+      const throttled = await request(callback, { method: 'GET' }, overrides)
+      expect(throttled.status).toBe(429)
+      expect(throttled.headers.get('Retry-After')).toBe('120')
+      const pending = await env.DB.prepare(
+        'SELECT status FROM device_sessions WHERE device_id = ?1',
+      )
+        .bind(url.searchParams.get('device_id')).first<{ status: string }>()
+      expect(pending?.status).toBe('pending')
+      const retained = await env.DB.prepare(
+        "SELECT COUNT(*) as count FROM oauth_request_tokens WHERE oauth_token = 'req-token'",
+      ).first<{ count: number }>()
+      expect(Number(retained?.count)).toBe(1)
+      const completed = await request(callback, { method: 'GET' }, overrides)
+      expect(completed.status).toBe(200)
+      const authorized = await env.DB.prepare(
+        'SELECT status FROM device_sessions WHERE device_id = ?1',
+      )
+        .bind(url.searchParams.get('device_id')).first<{ status: string }>()
+      expect(authorized?.status).toBe('authorized')
+      const consumed = await env.DB.prepare(
+        "SELECT COUNT(*) as count FROM oauth_request_tokens WHERE oauth_token = 'req-token'",
+      ).first<{ count: number }>()
+      expect(Number(consumed?.count)).toBe(0)
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
   it('stores access token secrets encrypted and still finalizes sessions', async () => {
     const start = await request('/v1/device/session/start', {
       method: 'POST',

--- a/broker/tests/discogs-rate-limit.test.ts
+++ b/broker/tests/discogs-rate-limit.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import {
+  DiscogsRateLimitError,
+  withDiscogsRateLimitRecovery,
+} from '../src/discogs-rate-limit'
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+it.each(['request_token', 'access_token'] as const)(
+  'recovers once from a transient 429 at %s, after the requested delay',
+  async (stage) => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const send = vi.fn()
+      .mockResolvedValueOnce(
+        new Response('', { status: 429, headers: { 'Retry-After': '2' } }),
+      )
+      .mockResolvedValueOnce(new Response('ok'))
+    const pending = withDiscogsRateLimitRecovery(stage, send)
+    await vi.advanceTimersByTimeAsync(1999)
+    expect(send).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect((await pending).status).toBe(200)
+    expect(send).toHaveBeenCalledTimes(2)
+  },
+)
+
+it('stops after a second 429 and preserves its retry instruction', async () => {
+  vi.useFakeTimers()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  const send = vi.fn()
+    .mockResolvedValueOnce(
+      new Response('', { status: 429, headers: { 'Retry-After': '0' } }),
+    )
+    .mockResolvedValueOnce(
+      new Response('', { status: 429, headers: { 'Retry-After': '90' } }),
+    )
+  const failure = withDiscogsRateLimitRecovery('request_token', send).catch((
+    error,
+  ) => error)
+  await vi.runAllTimersAsync()
+  expect(await failure).toBeInstanceOf(DiscogsRateLimitError)
+  expect((await failure).retryAfterSeconds).toBe(90)
+  expect(send).toHaveBeenCalledTimes(2)
+})
+
+it('does not shorten an upstream wait beyond the automatic retry budget', async () => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  const send = vi.fn().mockResolvedValue(
+    new Response('', {
+      status: 429,
+      headers: { 'Retry-After': '120' },
+    }),
+  )
+  await expect(withDiscogsRateLimitRecovery('access_token', send)).rejects
+    .toMatchObject({
+      retryAfterSeconds: 120,
+    })
+  expect(send).toHaveBeenCalledTimes(1)
+})
+
+it('honors an HTTP-date Retry-After', async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-09-07T07:00:00Z'))
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  const send = vi.fn()
+    .mockResolvedValueOnce(
+      new Response('', {
+        status: 429,
+        headers: { 'Retry-After': 'Mon, 07 Sep 2026 07:00:30 GMT' },
+      }),
+    )
+    .mockResolvedValueOnce(new Response('ok'))
+  const pending = withDiscogsRateLimitRecovery('request_token', send)
+  await vi.advanceTimersByTimeAsync(29999)
+  expect(send).toHaveBeenCalledTimes(1)
+  await vi.advanceTimersByTimeAsync(1)
+  expect((await pending).status).toBe(200)
+})
+
+it.each([null, '-1', '1oops', ''])(
+  'uses a conservative fallback for Retry-After %s',
+  async (value) => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const send = vi.fn()
+      .mockResolvedValueOnce(
+        new Response('', {
+          status: 429,
+          headers: value === null ? {} : { 'Retry-After': value },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('ok'))
+    const pending = withDiscogsRateLimitRecovery('request_token', send)
+    await vi.advanceTimersByTimeAsync(59999)
+    expect(send).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect((await pending).status).toBe(200)
+  },
+)
+
+it('does not retry an ambiguous network failure during token exchange', async () => {
+  const error = new Error('connection lost')
+  const send = vi.fn().mockRejectedValue(error)
+  await expect(withDiscogsRateLimitRecovery('access_token', send)).rejects.toBe(
+    error,
+  )
+  expect(send).toHaveBeenCalledTimes(1)
+})
+
+it.each([401, 403, 500])(
+  'does not retry upstream status %s',
+  async (status) => {
+    const send = vi.fn().mockResolvedValue(new Response('', { status }))
+    expect((await withDiscogsRateLimitRecovery('request_token', send)).status)
+      .toBe(status)
+    expect(send).toHaveBeenCalledTimes(1)
+  },
+)
+
+it('logs only numeric quota information, never bodies or arbitrary header values', async () => {
+  const log = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  const send = vi.fn().mockResolvedValue(
+    new Response('secret response body', {
+      status: 429,
+      headers: {
+        'Retry-After': '120',
+        'X-Discogs-Ratelimit': '60',
+        'X-Discogs-Ratelimit-Remaining': '0',
+        'X-Discogs-Ratelimit-Used': 'secret header value',
+      },
+    }),
+  )
+  await expect(withDiscogsRateLimitRecovery('request_token', send)).rejects
+    .toBeInstanceOf(DiscogsRateLimitError)
+  expect(log).toHaveBeenCalledWith('discogs rate limit', {
+    stage: 'request_token',
+    retry_after_seconds: 120,
+    limit: 60,
+    remaining: 0,
+    used: null,
+  })
+  expect(JSON.stringify(log.mock.calls)).not.toContain('secret')
+})
+
+it('returns search throttling immediately within the MCP client deadline', async () => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  const send = vi.fn().mockResolvedValue(
+    new Response('', { status: 429, headers: { 'Retry-After': '30' } }),
+  )
+  await expect(withDiscogsRateLimitRecovery('search', send)).rejects
+    .toMatchObject({ retryAfterSeconds: 30 })
+  expect(send).toHaveBeenCalledTimes(1)
+})

--- a/broker/tests/discogs-recovery.test.ts
+++ b/broker/tests/discogs-recovery.test.ts
@@ -1,0 +1,251 @@
+import { env } from 'cloudflare:test'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import worker from '../src/index'
+
+const COOLDOWN = 'discogs-api-cooldown'
+const PACING = 'discogs-api-global'
+
+beforeEach(async () => {
+  for (
+    const table of [
+      'device_sessions',
+      'oauth_request_tokens',
+      'discogs_search_cache',
+      'rate_limit_state',
+    ]
+  ) {
+    await env.DB.prepare(`DELETE FROM ${table}`).run()
+  }
+  const now = Math.floor(Date.now() / 1000)
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode('recovery-session'),
+  )
+  const hash = Array.from(
+    new Uint8Array(digest),
+    n => n.toString(16).padStart(2, '0'),
+  ).join('')
+  await env.DB.prepare(`INSERT INTO device_sessions
+    (device_id, pending_token, status, poll_interval_seconds, created_at, updated_at,
+      expires_at, oauth_access_token, oauth_access_token_secret, session_token_hash, session_expires_at)
+    VALUES ('recovery-device', 'recovery-pending', 'finalized', 5, ?1, ?1, ?2,
+      'synthetic-token', 'synthetic-secret', ?3, ?2)`)
+    .bind(now, now + 3600, hash).run()
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+function request(
+  path: string,
+  init: RequestInit,
+  overrides: Partial<typeof env> = {},
+) {
+  return worker.fetch(new Request(`https://broker.test${path}`, init), {
+    ...env,
+    DISCOGS_MIN_INTERVAL_MS: '1',
+    ...overrides,
+  })
+}
+
+function search(title: string, overrides: Partial<typeof env> = {}) {
+  return request('/v1/discogs/proxy/search', {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer recovery-session',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ artist: 'Recovery Artist', title }),
+  }, overrides)
+}
+
+async function setDeadline(bucket: string, deadlineMs: number) {
+  await env.DB.prepare(
+    `INSERT INTO rate_limit_state (bucket, last_request_at_ms)
+    VALUES (?1, ?2) ON CONFLICT(bucket) DO UPDATE SET last_request_at_ms = excluded.last_request_at_ms`,
+  )
+    .bind(bucket, deadlineMs).run()
+}
+
+it('shares cooldowns across search and OAuth, serves cached results, and recovers after expiry', async () => {
+  const upstream = vi.spyOn(globalThis, 'fetch')
+    .mockResolvedValueOnce(
+      new Response('', { status: 429, headers: { 'Retry-After': '180' } }),
+    )
+    .mockResolvedValueOnce(new Response(JSON.stringify({ results: [] })))
+  const first = await search('First')
+  expect(first.status).toBe(429)
+  expect(first.headers.get('Retry-After')).toBe('180')
+  const second = await search('Second')
+  expect(second.status).toBe(429)
+  expect(Number(second.headers.get('Retry-After'))).toBeGreaterThanOrEqual(179)
+  expect(upstream).toHaveBeenCalledTimes(1)
+
+  const start = await request('/v1/device/session/start', {
+    method: 'POST',
+    headers: { 'x-reklawdbox-broker-token': env.BROKER_CLIENT_TOKEN },
+  })
+  const started = await start.json<{ auth_url: string }>()
+  const link = new URL(started.auth_url)
+  expect((await request(link.pathname + link.search, {})).status).toBe(429)
+  expect(upstream).toHaveBeenCalledTimes(1)
+
+  const now = Math.floor(Date.now() / 1000)
+  await env.DB.prepare(
+    `INSERT INTO discogs_search_cache (cache_key, response_json, cached_at, expires_at)
+    VALUES ('recovery artist|cached|', ?1, ?2, ?3)`,
+  )
+    .bind(
+      JSON.stringify({ result: null, match_quality: 'none', cache_hit: false }),
+      now,
+      now + 3600,
+    ).run()
+  const cached = await search('Cached')
+  expect(cached.status).toBe(200)
+  expect(await cached.json()).toMatchObject({ result: null, cache_hit: true })
+  expect(upstream).toHaveBeenCalledTimes(1)
+
+  await setDeadline(COOLDOWN, Date.now() - 1)
+  const recovered = await search('Second')
+  expect(recovered.status).toBe(200)
+  expect(await recovered.json()).toMatchObject({
+    result: null,
+    cache_hit: false,
+  })
+  expect(upstream).toHaveBeenCalledTimes(2)
+})
+
+it('rejects an excessive queue promptly without growing the backlog or calling Discogs', async () => {
+  const reserved = Date.now() + 31000
+  await setDeadline(PACING, reserved)
+  const upstream = vi.spyOn(globalThis, 'fetch')
+  const started = Date.now()
+  const response = await search('Queued', { DISCOGS_MIN_INTERVAL_MS: '1100' })
+  expect(response.status).toBe(503)
+  expect(response.headers.get('Cache-Control')).toBe('no-store')
+  expect(Number(response.headers.get('Retry-After'))).toBeGreaterThanOrEqual(31)
+  expect(await response.json()).toMatchObject({ error: 'broker_busy' })
+  expect(Date.now() - started).toBeLessThan(1000)
+  expect(upstream).not.toHaveBeenCalled()
+  const row = await env.DB.prepare(
+    'SELECT last_request_at_ms FROM rate_limit_state WHERE bucket = ?1',
+  )
+    .bind(PACING).first<{ last_request_at_ms: number }>()
+  expect(row?.last_request_at_ms).toBe(reserved)
+})
+
+it('rechecks cooldowns after an already queued request wakes', async () => {
+  await setDeadline(PACING, Date.now() + 300)
+  const upstream = vi.spyOn(globalThis, 'fetch')
+  const pending = search('Already queued')
+  await new Promise(resolve => setTimeout(resolve, 75))
+  await setDeadline(COOLDOWN, Date.now() + 60000)
+  const response = await pending
+  expect(response.status).toBe(429)
+  expect(upstream).not.toHaveBeenCalled()
+})
+
+it('keeps the longest cooldown when in-flight upstream responses finish out of order', async () => {
+  const replies: Array<(response: Response) => void> = []
+  const upstream = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+    new Promise<Response>(resolve => replies.push(resolve))
+  )
+  const first = search('Concurrent A')
+  const second = search('Concurrent B')
+  await vi.waitFor(() => expect(upstream).toHaveBeenCalledTimes(2))
+  replies[0](
+    new Response('', { status: 429, headers: { 'Retry-After': '180' } }),
+  )
+  await vi.waitFor(async () => {
+    const row = await env.DB.prepare(
+      'SELECT last_request_at_ms FROM rate_limit_state WHERE bucket = ?1',
+    )
+      .bind(COOLDOWN).first<{ last_request_at_ms: number }>()
+    expect(Number(row?.last_request_at_ms)).toBeGreaterThan(Date.now() + 179000)
+  })
+  replies[1](
+    new Response('', { status: 429, headers: { 'Retry-After': '60' } }),
+  )
+  expect((await first).status).toBe(429)
+  const secondResponse = await second
+  expect(secondResponse.status).toBe(429)
+  expect(Number(secondResponse.headers.get('Retry-After')))
+    .toBeGreaterThanOrEqual(179)
+  const row = await env.DB.prepare(
+    'SELECT last_request_at_ms FROM rate_limit_state WHERE bucket = ?1',
+  )
+    .bind(COOLDOWN).first<{ last_request_at_ms: number }>()
+  expect(Number(row?.last_request_at_ms)).toBeGreaterThan(Date.now() + 179000)
+})
+
+it('routes the complete OAuth and search flow through the configured egress binding', async () => {
+  const direct = vi.spyOn(globalThis, 'fetch')
+  const routed = vi.fn()
+    .mockResolvedValueOnce(
+      new Response('oauth_token=req-token&oauth_token_secret=req-secret'),
+    )
+    .mockResolvedValueOnce(
+      new Response('oauth_token=access-token&oauth_token_secret=access-secret'),
+    )
+    .mockResolvedValueOnce(new Response(JSON.stringify({ results: [] })))
+  const overrides = { DISCOGS_EGRESS: { fetch: routed } as unknown as Fetcher }
+  const start = await request('/v1/device/session/start', {
+    method: 'POST',
+    headers: { 'x-reklawdbox-broker-token': env.BROKER_CLIENT_TOKEN },
+  }, overrides)
+  const started = await start.json<
+    { auth_url: string; device_id: string; pending_token: string }
+  >()
+  const link = new URL(started.auth_url)
+  expect((await request(link.pathname + link.search, {}, overrides)).status)
+    .toBe(302)
+  const callback = '/v1/discogs/oauth/callback' + link.search
+    + '&oauth_token=req-token&oauth_verifier=verifier'
+  expect((await request(callback, {}, overrides)).status).toBe(200)
+  const finalized = await request('/v1/device/session/finalize', {
+    method: 'POST',
+    headers: {
+      'x-reklawdbox-broker-token': env.BROKER_CLIENT_TOKEN,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      device_id: started.device_id,
+      pending_token: started.pending_token,
+    }),
+  }, overrides)
+  expect(finalized.status).toBe(200)
+  const session = await finalized.json<{ session_token: string }>()
+  const result = await request('/v1/discogs/proxy/search', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${session.session_token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ artist: 'Gateway Artist', title: 'Gateway Track' }),
+  }, overrides)
+  expect(result.status).toBe(200)
+  expect(routed.mock.calls.map(([url]) => new URL(url).pathname)).toEqual([
+    '/oauth/request_token',
+    '/oauth/access_token',
+    '/database/search',
+  ])
+  expect(direct).not.toHaveBeenCalled()
+  const health = await request('/v1/health', {}, overrides)
+  expect(await health.json()).toMatchObject({
+    status: 'ok',
+    discogs_egress: 'gateway',
+  })
+})
+
+it('does not fall back to direct Worker egress when the configured route fails', async () => {
+  const direct = vi.spyOn(globalThis, 'fetch')
+  const routed = vi.fn().mockRejectedValue(
+    new Error('synthetic egress failure'),
+  )
+  const response = await search('Failure', {
+    DISCOGS_EGRESS: { fetch: routed } as unknown as Fetcher,
+  })
+  expect(response.status).toBe(502)
+  expect(await response.json()).toMatchObject({ error: 'discogs_unavailable' })
+  expect(routed).toHaveBeenCalledTimes(1)
+  expect(direct).not.toHaveBeenCalled()
+})

--- a/broker/tests/setup.ts
+++ b/broker/tests/setup.ts
@@ -9,6 +9,7 @@ declare module 'cloudflare:test' {
     DISCOGS_CONSUMER_SECRET: string
     BROKER_STATE_ENCRYPTION_KEY: string
     DISCOGS_MIN_INTERVAL_MS?: string
+    DISCOGS_EGRESS?: Fetcher
     BROKER_CLIENT_TOKEN: string
     BROKER_PUBLIC_BASE_URL: string
     ALLOW_UNAUTHENTICATED_BROKER?: string
@@ -24,6 +25,7 @@ declare global {
       DISCOGS_CONSUMER_SECRET: string
       BROKER_STATE_ENCRYPTION_KEY: string
       DISCOGS_MIN_INTERVAL_MS?: string
+      DISCOGS_EGRESS?: Fetcher
       BROKER_CLIENT_TOKEN: string
       BROKER_PUBLIC_BASE_URL: string
       ALLOW_UNAUTHENTICATED_BROKER?: string

--- a/broker/vitest.config.ts
+++ b/broker/vitest.config.ts
@@ -10,8 +10,11 @@ const migrations = await readD1Migrations(migrationsPath)
 export default defineConfig({
   plugins: [
     cloudflareTest({
+      // Baseline tests must never create remote sessions or contact Discogs.
+      remoteBindings: false,
       wrangler: {
         configPath: './wrangler.toml',
+        environment: 'test',
       },
       miniflare: {
         d1Databases: {

--- a/broker/wrangler.toml
+++ b/broker/wrangler.toml
@@ -1,7 +1,15 @@
 name = "reklawdbox-discogs-broker"
+account_id = "2584e96da1501a94e4af53e21f8f018d"
 main = "src/index.ts"
 compatibility_date = "2026-02-19"
 workers_dev = true
+
+# Public internet through the personal account's free Workers VPC beta.
+# Gateway egress avoids the ordinary Worker fetch pool; it is not a dedicated IP.
+[[vpc_networks]]
+binding = "DISCOGS_EGRESS"
+network_id = "cf1:network"
+remote = true
 
 [triggers]
 crons = ["0 * * * *"]
@@ -11,3 +19,8 @@ binding = "DB"
 database_name = "reklawdbox-broker"
 database_id = "48abbf51-84c5-4d65-8bad-d8dcea877592"
 migrations_dir = "migrations"
+
+# Vitest supplies an isolated D1 database and explicit mock egress bindings.
+[env.test]
+d1_databases = []
+vpc_networks = []

--- a/site/src/content/docs/troubleshooting/index.mdx
+++ b/site/src/content/docs/troubleshooting/index.mdx
@@ -86,6 +86,24 @@ complete.
 
 Device flow expired before browser authorization completed. Call `lookup_discogs` again — complete the browser step promptly.
 
+### "broker ... HTTP 429" or "broker ... HTTP 503"
+
+HTTP 429 means Discogs has rate limited the broker. HTTP 503 with
+`broker_busy` means the broker's request queue is full. Wait for the
+`Retry-After` interval shown in the error before trying again. These errors
+do not mean a release is missing, and successful cached lookups can still work.
+
+If this happens in the browser during authorization, wait and retry the same
+page. A rate limited callback preserves the authorization state. If the
+device session has expired, call `lookup_discogs` again for a fresh link.
+The browser flow retries an explicit upstream 429 once automatically when
+its wait is at most 60 seconds.
+
+MCP searches return retry instructions immediately. The CLI can retry up to
+four total attempts, honoring waits of at most 120 seconds each. Longer
+instructions are shown without retrying early. Repeated throttling needs a
+broker connectivity check; disconnecting your session will not fix it.
+
 ---
 
 ## Essentia / audio analysis

--- a/src/adapters/providers/discogs/client.rs
+++ b/src/adapters/providers/discogs/client.rs
@@ -113,8 +113,7 @@ impl fmt::Display for LookupError {
                 let retry_after_seconds = error
                     .retry_after
                     .as_deref()
-                    .and_then(|value| value.parse::<u64>().ok())
-                    .map(|seconds| seconds.min(120));
+                    .and_then(|value| value.trim().parse::<u64>().ok());
                 match (retryable, retry_after_seconds) {
                     (true, Some(seconds)) => write!(
                         f,
@@ -292,6 +291,17 @@ mod tests {
         assert_eq!(err.http_status(), Some(502));
         assert_eq!(err.diagnostic_body(), Some("bad gateway"));
         assert!(err.auth_remediation().is_none());
+    }
+
+    #[test]
+    fn lookup_error_preserves_retry_instructions_beyond_the_automatic_wait_budget() {
+        for status in [429, 503] {
+            let err = LookupError::http(status, Some("999".to_string()), "private".to_string());
+            assert_eq!(
+                err.to_string(),
+                format!("broker proxy HTTP {status} (retryable; retry after 999s)")
+            );
+        }
     }
 
     #[test]

--- a/src/cli/hydrate/discogs.rs
+++ b/src/cli/hydrate/discogs.rs
@@ -102,16 +102,21 @@ pub(super) fn http_retry_metadata(
     error: &discogs::LookupError,
     attempt: u32,
 ) -> Option<DiscogsHttpRetry<'_>> {
+    const MAX_AUTOMATIC_WAIT_SECONDS: u64 = 120;
     let status = error.http_status()?;
-    let wait_seconds = match status {
-        429 => error
-            .retry_after()
-            .and_then(|value| value.parse::<u64>().ok())
-            .unwrap_or(5)
-            .min(120),
+    let fallback_seconds = match status {
+        429 => 5,
         500..=599 => 5 * 2u64.pow(attempt),
         _ => return None,
     };
+    let wait_seconds = error
+        .retry_after()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(fallback_seconds);
+    // Return long retry instructions to the caller instead of retrying early.
+    if wait_seconds > MAX_AUTOMATIC_WAIT_SECONDS {
+        return None;
+    }
     Some(DiscogsHttpRetry {
         status,
         wait_seconds,
@@ -136,9 +141,8 @@ where
         match lookup().await {
             Ok(result) => return Ok(result),
             Err(error) => {
-                // Defence-in-depth: the broker handles Discogs 429s internally,
-                // but platform-level rate limits (Cloudflare) or custom brokers
-                // may 429.
+                // The broker returns upstream cooldowns as 429 and queue
+                // backpressure as 503, with Retry-After for both.
                 let backoff = if let Some(retry) = http_retry_metadata(&error, attempt) {
                     if retry.status == 429 {
                         tracing::warn!(

--- a/src/cli/hydrate/tests.rs
+++ b/src/cli/hydrate/tests.rs
@@ -130,9 +130,9 @@ fn discogs_cli_retry_keeps_bounded_sanitized_diagnostic_out_of_display() {
 }
 
 #[test]
-fn discogs_cli_retry_metadata_preserves_429_cap_and_5xx_backoff() {
+fn discogs_cli_retry_metadata_honors_server_delays_within_budget() {
     let rate_limited =
-        discogs::LookupError::http(429, Some("999".to_string()), "rate limited".to_string());
+        discogs::LookupError::http(429, Some("120".to_string()), "rate limited".to_string());
     let retry = discogs_cli::http_retry_metadata(&rate_limited, 3)
         .expect("HTTP 429 should remain retryable");
     assert_eq!(retry.wait_seconds, 120);
@@ -143,8 +143,40 @@ fn discogs_cli_retry_metadata_preserves_429_cap_and_5xx_backoff() {
         .expect("HTTP 503 should remain retryable");
     assert_eq!(retry.wait_seconds, 40);
 
+    let busy = discogs::LookupError::http(503, Some("61".to_string()), "busy".to_string());
+    assert_eq!(
+        discogs_cli::http_retry_metadata(&busy, 0)
+            .unwrap()
+            .wait_seconds,
+        61
+    );
+
     let bad_request = discogs::LookupError::http(400, None, "bad request".to_string());
     assert!(discogs_cli::http_retry_metadata(&bad_request, 0).is_none());
+}
+
+#[tokio::test]
+async fn hydrate_discogs_returns_long_retry_instructions_without_an_early_retry() {
+    for status in [429, 503] {
+        let calls = Arc::new(AtomicU32::new(0));
+        let result = discogs_cli::lookup_with_retry_for_test(
+            {
+                let calls = calls.clone();
+                move || {
+                    calls.fetch_add(1, Ordering::Relaxed);
+                    std::future::ready(Err::<Option<discogs::DiscogsResult>, _>(
+                        discogs::LookupError::http(status, Some("999".to_string()), String::new()),
+                    ))
+                }
+            },
+            |_| async { panic!("a long server cooldown must not be shortened") },
+        )
+        .await;
+        let error = result.expect_err("the caller should receive the full retry instruction");
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert_eq!(error.retry_after(), Some("999"));
+        assert!(error.to_string().contains("retry after 999s"));
+    }
 }
 
 #[test]

--- a/stratum-dsp/src/features/period/novelty.rs
+++ b/stratum-dsp/src/features/period/novelty.rs
@@ -1025,9 +1025,7 @@ mod tests {
         let mut spectrogram = vec![vec![0.1f32; 1024]; 10];
 
         // Frame 5: higher energy
-        for bin in &mut spectrogram[5] {
-            *bin = 1.0f32;
-        }
+        spectrogram[5].fill(1.0f32);
 
         let novelty = energy_flux_novelty(&spectrogram).unwrap();
 


### PR DESCRIPTION
Discogs was returning HTTP 429 to the broker through ordinary Cloudflare Worker egress, preventing authorization and searches despite very low broker traffic. Route OAuth and search through the personal account's free Workers VPC/Gateway binding, share upstream cooldowns in D1, and return queue backpressure promptly within the MCP request budget. Preserve complete retry instructions in the Rust client and honor 503 retry delays in the CLI.

The incident patch is committed along with the recovery changes. No database migration is needed. Gateway remains shared egress, so future throttling remains possible; the documented cooldown and retry behavior handles that case.

Validation:

- Workspace formatting, clippy, 1,628 tests (35 ignored), release build, version/help, and MCP smoke passed. The final candidate used Rust 1.98, matching CI; its new Clippy lint required replacing an equivalent DSP test assignment loop with slice fill.
- Broker typecheck, build, and all 79 Worker-runtime tests passed, including shared/concurrent cooldowns, callback retry, bounded queueing, and complete bound OAuth/search routing.
- Documentation parser tests (59), site build, live contracts (52 MCP tools, 11 workflows, 44 pages), and scoped MCP/CLI/SOP/user-journey semantic reviews passed.
- Live free-route comparison: Gateway HTTP 200 twice; ordinary Worker egress HTTP 429 between them.
- Production Worker version `a5d8ed1c-2adf-4478-a054-7b9a3bd4d3e0` is deployed from `afc6546`. Health/auth boundaries and fresh OAuth request-token acquisition passed. Sanitized production logs recorded 133 successful authenticated searches with no exceptions or rate-limit events; these are existing traffic, not a fresh smoke session.
- [v0.33.1](https://github.com/ryan-voitiskis/reklawdbox/releases/tag/v0.33.1) is published; all main/tag and release checks passed. The Homebrew binary was installed, verified against the published package, and passed the real-library MCP smoke with 52 tools and zero protocol violations.
- Fresh browser authorization and authenticated production searches, positive/negative caching, malformed input, bounded queue backpressure/recovery, and installed MCP session reuse after restart passed. The smoke found a null-album compatibility failure, repaired and deployed in [PR #35](https://github.com/ryan-voitiskis/reklawdbox/pull/35). Final production version `b193d2c8-a924-4406-9300-34080b29cea7` serves 100% of traffic and passes the complete normal Music MCP smoke. Deterministic 429 recovery passed isolated Worker/D1 integration tests.
