### PR TITLE
fix(broker): accept null albums from existing clients

### DIFF
--- a/broker/README.md
+++ b/broker/README.md
@@ -14,6 +14,10 @@ Prerequisite: Node.js `>=20.19.0`.
 - `GET /v1/discogs/oauth/callback`
 - `POST /v1/discogs/proxy/search`
 
+Search requests require non-empty `artist` and `title` strings. `album` is
+optional: omit it or send `null` or an empty string to search without an album.
+These forms use the same cache entry. Other non-string album values are invalid.
+
 ## Required secrets
 
 Set with `wrangler secret put`:

--- a/broker/src/index.ts
+++ b/broker/src/index.ts
@@ -1968,7 +1968,8 @@ function optionalStringField(
   maxLength: number,
 ): string | undefined {
   const value = body[field]
-  if (value === undefined) {
+  // Rust clients serialize an absent optional album as JSON null.
+  if (value === undefined || value === null) {
     return undefined
   }
   if (typeof value !== 'string') {

--- a/broker/tests/broker.test.ts
+++ b/broker/tests/broker.test.ts
@@ -2191,8 +2191,12 @@ describe('discogs proxy search caching', () => {
       '[]',
       'null',
       JSON.stringify({ artist: ['Artist'], title: 'Track' }),
+      JSON.stringify({ artist: null, title: 'Track' }),
       JSON.stringify({ artist: 'Artist', title: 123 }),
-      JSON.stringify({ artist: 'Artist', title: 'Track', album: null }),
+      JSON.stringify({ artist: 'Artist', title: null }),
+      JSON.stringify({ artist: 'Artist', title: 'Track', album: 123 }),
+      JSON.stringify({ artist: 'Artist', title: 'Track', album: [] }),
+      JSON.stringify({ artist: 'Artist', title: 'Track', album: {} }),
     ]
 
     for (const bodyText of cases) {
@@ -2210,6 +2214,60 @@ describe('discogs proxy search caching', () => {
         error: string
       }>()
       expect(body.error).toBe('invalid_params')
+    }
+  })
+
+  it('accepts the Rust client null album and shares cache with omitted or empty albums', async () => {
+    const sessionToken = 'session-null-album'
+    await insertFinalizedSession(sessionToken)
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = new URL(
+          typeof input === 'string' ? input : input.toString(),
+        )
+        expect(url.pathname).toBe('/database/search')
+        expect(url.searchParams.has('release_title')).toBe(false)
+        return new Response(
+          JSON.stringify({
+            results: [{
+              title: 'Nullable Artist - Nullable Track',
+              year: 2026,
+              label: ['Test Label'],
+              genre: ['Electronic'],
+              style: ['House'],
+              uri: '/release/123',
+            }],
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        )
+      },
+    )
+
+    try {
+      for (const album of [null, undefined, '', '  ']) {
+        const response = await request('/v1/discogs/proxy/search', {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${sessionToken}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            artist: 'Nullable Artist',
+            title: 'Nullable Track',
+            album,
+          }),
+        })
+        expect(response.status).toBe(200)
+        const body = await response.json<{
+          result: { title: string }
+          cache_hit: boolean
+        }>()
+        expect(body.result.title).toBe('Nullable Artist - Nullable Track')
+        expect(body.cache_hit).toBe(album !== null)
+      }
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      fetchSpy.mockRestore()
     }
   })
 


### PR DESCRIPTION
The production MCP smoke found that lookups without an album failed with HTTP 400: the Rust client serializes an absent album as JSON `null`, but the broker required every supplied album to be a string.

Treat a null optional album as absent so existing clients can search without an album. Omitted, null, and empty album values share a cache entry. Required artist/title validation and rejection of other album types remain unchanged. No client release, database migration, or runtime configuration change is needed.

Validation:

- Reproduced `400 invalid_params` / `album must be a string` against production and with the new Worker/D1 regression before the fix.
- Broker locked install, typecheck, deployment build, and 80 tests passed. Regression coverage exercises the actual request, upstream lookup, cache equivalence, and invalid types.
- Rust 1.98 formatting, dprint, clippy, workspace tests, release build, version/help passed.
- Documentation parser tests, site build, and live contracts passed (52 MCP tools, 11 workflows, 44 pages).
- Four scoped semantic reviews (MCP, CLI, SOPs, and user journey) found no actionable issues.
- Deployed production version `b193d2c8-a924-4406-9300-34080b29cea7` at 100% traffic. All six existing bindings and runtime settings were preserved and verified before deployment.
- Production regression returns a fresh Massive Attack / Teardrop match for `album: null`; omitted/empty/whitespace albums reuse the same cache entry.
- Installed Homebrew v0.33.1 passed the normal Music MCP configuration: authenticated lookup, positive/negative caching, a genuine miss without an album, invalid input, and saved authorization reused after a fresh process, with zero protocol violations.
- Final HTTP smoke passed malformed/oversized input and cache checks. A six-request burst exercised prompt 503 backpressure; retrying after the five-second instruction succeeded without caching the rejection. Production health reports `ok` / `gateway`.
